### PR TITLE
fix(PL-2229): group.AllMembers does not include inherited people

### DIFF
--- a/pkg/live/catalog.go
+++ b/pkg/live/catalog.go
@@ -154,6 +154,7 @@ func (c *Catalog) Load(globExpr string) error {
 		c.resolveInheritedGroups(person)
 		for _, group := range person.InheritedGroups {
 			group.IndirectMembers = append(group.IndirectMembers, person)
+			group.AllMembers = append(group.AllMembers, person)
 		}
 	}
 


### PR DESCRIPTION
Required for @ayahajar's PR: https://github.com/nestoca/people/pull/31